### PR TITLE
Complete pt_br localization and fix power_shot variables

### DIFF
--- a/common/src/main/resources/assets/archers/lang/pt_br.json
+++ b/common/src/main/resources/assets/archers/lang/pt_br.json
@@ -3,15 +3,16 @@
   "item.archers.auto_fire_hook.description_1": "Libera automaticamente a flecha carregada.",
   "item.archers.auto_fire_hook.description_2": "Pode ser aplicado a armas de longo alcance, em uma bigorna.",
   "item.ranged_weapon.pull_time": "%1$s seg Tempo de carregamento",
-
   "block.archers.archers_workbench": "Mesa de artesão de arqueria",
   "block.archers.archers_workbench.hint": "Banco de trabalho para aldeões artesãos de arqueria.",
   "entity.minecraft.villager.archery_artisan": "Artesão de arqueria",
   "entity.minecraft.villager.archers.archery_artisan": "Artesão de arqueria",
   "entity.minecraft.villager.archers:archery_artisan": "Artesão de arqueria",
-
   "item.archers.auto_fire_hook": "Gancho de Disparo Automático",
-
+  "item.archers.small_quiver": "Aljava",
+  "item.archers.medium_quiver": "Aljava de Caça",
+  "item.archers.large_quiver": "Aljava de Batalha",
+  "item.archers.quiver.hint": "Fornece flechas para arqueria quando equipada.",
   "item.archers.flint_spear": "Lança de sílex",
   "item.archers.iron_spear": "Lança de ferro",
   "item.archers.golden_spear": "Lança de ouro",
@@ -19,22 +20,19 @@
   "item.archers.netherite_spear": "Lança de netherite",
   "item.archers.aeternium_spear": "Lança de aeternium",
   "item.archers.ruby_spear": "Lança de rubi",
-
+  "item.archers.aether_spear": "Lança Sagrada",
   "item.archers.archer_armor_head": "Capuz de arqueiro",
   "item.archers.archer_armor_chest": "Túnica de arqueiro",
   "item.archers.archer_armor_legs": "Calças de arqueiro",
   "item.archers.archer_armor_feet": "Botas de arqueiro",
-
   "item.archers.ranger_armor_head": "Capuz de ranger",
   "item.archers.ranger_armor_chest": "Túnica de ranger",
   "item.archers.ranger_armor_legs": "Calças de ranger",
   "item.archers.ranger_armor_feet": "Botas de ranger",
-
   "item.archers.netherite_ranger_armor_head": "Capuz de ranger de netherite",
   "item.archers.netherite_ranger_armor_chest": "Túnica de ranger de netherite",
   "item.archers.netherite_ranger_armor_legs": "Calças de ranger de netherite",
   "item.archers.netherite_ranger_armor_feet": "Botas de ranger de netherite",
-
   "item.archers.composite_longbow": "Arco longo composto",
   "item.archers.mechanic_shortbow": "Arco curto mecânico",
   "item.archers.royal_longbow": "Arco longo real",
@@ -48,34 +46,36 @@
   "item.archers.crystal_longbow": "Arco longo de cristal",
   "item.archers.ruby_rapid_crossbow": "Besta rápida de rubi",
   "item.archers.ruby_heavy_crossbow": "Besta pesada de rubi",
-
+  "item.archers.aether_longbow": "Arco de Prata da Acrópole",
+  "item.archers.aether_rapid_crossbow": "Besta Celeste",
+  "item.archers.aether_heavy_crossbow": "Balista da Valquíria",
   "item.archers.spell_book/archer": "Manual de arqueria",
-
+  "item.archers.spell_book/archer.spell_binding.description": "Manual dos Arqueiros, que usam armas de longo alcance e habilidades de arqueria para derrotar inimigos à distância\n- Pontos fortes: Causar alto dano à distância e manter a mobilidade\n- Pontos fracos: Inimigos com armadura pesada\n- Equipamento: Armadura moderada",
+  "item.archers.spell_scroll/archer": "Pergaminho de Arqueria",
   "spell.archers.power_shot.name": "Tiro poderoso",
-  "spell.archers.power_shot.description": "Habilidade passiva: flechas aplicam a Marca do Caçador no alvo por {effect_duration} segundos, aumentando o dano recebido em {damage_taken}, acumulando até {effect_amplifier} vezes.",
+  "spell.archers.power_shot.description": "Suas próximas {effect_amplifier_cap} flechas aplicam a Marca do Caçador no alvo por {effect_duration} segundos, aumentando o dano recebido em {damage_taken}, acumulando até {effect_amplifier_cap} vezes.",
+  "effect.archers.hunters_mark_stash": "Tiro Poderoso",
+  "effect.archers.hunters_mark_stash.description": "O próximo tiro aplica a Marca do Caçador",
   "effect.archers.hunters_mark": "Marcado",
   "effect.archers.hunters_mark.description": "Aumenta o dano recebido de todas as fontes",
-
   "spell.archers.entangling_roots.name": "Raízes entorpecentes",
   "spell.archers.entangling_roots.description": "Conjura raízes que brotam do chão na área próxima, desacelerando inimigos por {cloud_duration} segundos.",
   "effect.archers.entangling_roots": "Raízes entorpecentes",
   "effect.archers.entangling_roots.description": "Reduz a velocidade de movimento",
-
   "spell.archers.barrage.name": "Barrage",
   "spell.archers.barrage.description": "Dispara várias flechas em rápida sucessão.",
-
   "spell.archers.magic_arrow.name": "Flecha mágica",
   "spell.archers.magic_arrow.description": "Dispara uma flecha mágica que perfura todos os inimigos em seu caminho, causando {damage} de dano a cada alvo.",
-
   "advancements.rpg_series.path_choose_archer.title": "Caminho da arqueria",
   "advancements.rpg_series.path_choose_archer.description": "Crie um manual de arqueria",
-
   "advancements.rpg_series.spell_novice_archer.title": "Tiros letais",
   "advancements.rpg_series.spell_novice_archer.description": "Obtenha sua primeira habilidade de arqueria",
-
   "advancements.rpg_series.spell_master_archer.title": "Especialista em balística",
   "advancements.rpg_series.spell_master_archer.description": "Complete o manual de arqueria",
-
   "advancements.rpg_series.obtain_arrow.title": "Caminho do arqueiro",
-  "advancements.rpg_series.obtain_arrow.description": "Obtenha uma flecha"
+  "advancements.rpg_series.obtain_arrow.description": "Obtenha uma flecha",
+  "advancements.rpg_series.spell_cast_archer_book.title": "Treinamento de Arqueria",
+  "advancements.rpg_series.spell_cast_archer_book.description": "Use uma habilidade do Manual de Arqueria",
+  "advancements.rpg_series.trade_with_archery_artisan.title": "Venda de Arqueria",
+  "advancements.rpg_series.trade_with_archery_artisan.description": "Compre um item de um aldeão Artesão de Arqueria"
 }


### PR DESCRIPTION
Completes the Brazilian Portuguese translation for Archers (was 63/79, now 79/79).

New strings: the three quivers (including the equip hint), the aether-tier ranged weapons (Holy Spear, Silver Bow of the Acropolis, Sky Crossbow, Valkyrie Ballista), the Archer spell book class description, the Archery Scroll, the Power Shot effect, and the `rpg_series` advancements.

I also fixed `power_shot.description`: it still used `{effect_amplifier}` and was missing the "your next N arrows" wording from the current `en_us` (which uses `{effect_amplifier_cap}` twice). The old variable rendered literally in game, so I updated it to match `en_us`.

Terminology follows the file's existing choices (Arqueiro, arqueria, Aljava, Marca do Caçador). Placeholders preserved.
